### PR TITLE
Fix Supabase token retrieval for local dev and cloud deployments

### DIFF
--- a/tools_agent/agent.py
+++ b/tools_agent/agent.py
@@ -189,7 +189,14 @@ async def graph(config: RunnableConfig):
     cfg = GraphConfigPydantic(**config.get("configurable", {}))
     tools = []
 
+    # Try to get Supabase token from configurable first (local dev), then fallback to metadata (cloud)
     supabase_token = config.get("configurable", {}).get("x-supabase-access-token")
+    if not supabase_token:
+        supabase_token = config.get("metadata", {}).get("supabaseAccessToken")
+        logger.info(f"[Auth] Using Supabase token from metadata (cloud deployment)")
+    else:
+        logger.info(f"[Auth] Using Supabase token from configurable (local dev)")
+
     logger.info(f"[Auth] Supabase token present: {supabase_token is not None}, length: {len(supabase_token) if supabase_token else 0} chars")
 
     # Check RAG configuration


### PR DESCRIPTION
## Summary
Fixed token retrieval to support both local development and cloud deployments by checking configurable first, then falling back to metadata.

## Changes
- Updated `get_tools()` in `agent.py` to prioritize `configurable.x-supabase-access-token` (local dev)
- Falls back to `metadata.supabaseAccessToken` (cloud deployment)
- Added detailed logging to track which token source is being used

## Test plan
- [x] Verified local development uses configurable token
- [x] Verified cloud deployment uses metadata token
- [x] Logging provides clear indication of token source

🤖 Generated with [Claude Code](https://claude.com/claude-code)