### PR TITLE
Enable configurable headers for x-* headers

### DIFF
--- a/langgraph.json
+++ b/langgraph.json
@@ -7,5 +7,11 @@
   "python_version": "3.11",
   "auth": {
     "path": "./tools_agent/security/auth.py:auth"
+  },
+  "http": {
+    "configurable_headers": {
+      "include": ["x-*"],
+      "exclude": ["authorization"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
Configure LangGraph to pass headers with `x-` prefix into runtime config.

## Changes
- Add `http.configurable_headers` configuration to `langgraph.json`
- Include all headers starting with `x-*` (e.g., `x-supabase-access-token`)
- Exclude `authorization` header for security

## Impact
Enables supervisor agents to pass Supabase tokens to sub-agents via `x-supabase-access-token` header, allowing RAG tools to authenticate properly when called through the supervisor.